### PR TITLE
Fixed case of ConfigParser to configparser for python3

### DIFF
--- a/dementor.py
+++ b/dementor.py
@@ -7,7 +7,7 @@ import os
 import sys
 import argparse
 import binascii
-import ConfigParser
+import configparser
 import logging
 from time import sleep
 from threading import Thread
@@ -51,7 +51,7 @@ class SMBServer(Thread):
 
     def run(self):
         # mini config for the server
-        smbConfig = ConfigParser.ConfigParser()
+        smbConfig = configparser.ConfigParser()
         smbConfig.add_section('global')
         smbConfig.set('global', 'server_name','server_name')
         smbConfig.set('global', 'server_os','Windows')


### PR DESCRIPTION
If you run dementor.py in python3 it fails now, because they renamed the library in python3: 
- https://docs.python.org/3/library/configparser.html

```
# python3 dementor.py
Traceback (most recent call last):
  File "/root/NetNTLMtoSilverTicket/dementor.py", line 10, in <module>
    import ConfigParser
ModuleNotFoundError: No module named 'ConfigParser'
# sed -ie 's/ConfigParser/configparser/g' dementor.py
# python3 dementor.py
usage: dementor.py [-h] [-u USERNAME] [-p PASSWORD] [-d DOMAIN] [--ntlm NTLM] [--server] [--debug] [-q] listener target
dementor.py: error: the following arguments are required: listener, target
```